### PR TITLE
feat: generate square terrain based on max dim instead of width,height

### DIFF
--- a/frontend/src/lib/TerrainGenerator.test.ts
+++ b/frontend/src/lib/TerrainGenerator.test.ts
@@ -309,7 +309,7 @@ describe("TerrainGenerator", () => {
     expect(result.grid[0].length).toBeLessThanOrEqual(modelResolution + 2);
   });
 
-  it("applies coverage factor correctly", async () => {
+  it("applies coverage factor correctly and generates square terrain", async () => {
     // Test with two different coverage factors
     const modelResolution = 50;
     const smallCoverage = 1.0;
@@ -322,7 +322,7 @@ describe("TerrainGenerator", () => {
       .mockImplementationOnce(
         async () =>
           ({
-            // Small coverage result
+            // Small coverage result - should be square
             grid: [[10]],
             bounds: {
               min: { x: -10, y: -10 },
@@ -345,7 +345,7 @@ describe("TerrainGenerator", () => {
       .mockImplementationOnce(
         async () =>
           ({
-            // Large coverage result
+            // Large coverage result - should be square
             grid: [[10]],
             bounds: {
               min: { x: -40, y: -40 },
@@ -392,6 +392,10 @@ describe("TerrainGenerator", () => {
     // Larger coverage should result in a larger terrain size
     expect(largeWidth).toBeGreaterThan(smallWidth);
     expect(largeHeight).toBeGreaterThan(smallHeight);
+
+    // Terrain should be square (width should equal height)
+    expect(smallWidth).toEqual(smallHeight);
+    expect(largeWidth).toEqual(largeHeight);
 
     // Restore the original for other tests
     TerrainGenerator.generate = originalGenerateTemp;

--- a/frontend/src/lib/TerrainGenerator.ts
+++ b/frontend/src/lib/TerrainGenerator.ts
@@ -113,16 +113,19 @@ export default class TerrainGenerator {
     const maxY = Math.max(...ys);
     const widthOrig = maxX - minX;
     const heightOrig = maxY - minY;
-    const widthGeo = widthOrig * paddingFactor;
-    const heightGeo = heightOrig * paddingFactor;
+
+    // Use the maximum dimension to create a square terrain
+    const maxDimension = Math.max(widthOrig, heightOrig);
+    const squareSize = maxDimension * paddingFactor;
+
     const centerX = (minX + maxX) / 2;
     const centerY = (minY + maxY) / 2;
     return {
-      regionMinX: centerX - widthGeo,
-      regionMaxX: centerX + widthGeo,
-      regionMinY: centerY - heightGeo,
-      regionMaxY: centerY + heightGeo,
-      widthGeo,
+      regionMinX: centerX - squareSize,
+      regionMaxX: centerX + squareSize,
+      regionMinY: centerY - squareSize,
+      regionMaxY: centerY + squareSize,
+      widthGeo: squareSize,
     };
   }
 


### PR DESCRIPTION
### Problem
Previously, the terrain generator created rectangular terrain that matched the aspect ratio of the GPX track's bounding box. This resulted in inconsistent terrain shapes - long thin routes would generate long thin terrain, while compact routes would generate more square terrain.

### Solution
Modified `computeRectangularExtents` method in `TerrainGenerator` to:
- Calculate the maximum dimension (width or height) of the track's bounding box
- Apply the padding factor to this maximum dimension to create a square size
- Use this square size for both X and Y dimensions of the terrain

### Changes
- Updated `computeRectangularExtents` to use `Math.max(widthOrig, heightOrig)` for square calculation
- Enhanced test suite to verify square terrain generation
- Added assertions to confirm width equals height in generated terrain


Closes #28

