### PR TITLE
refactor: extract STL export logic into dedicated class with async callbacks

### DIFF
--- a/frontend/src/hooks/useModelBuilder.tsx
+++ b/frontend/src/hooks/useModelBuilder.tsx
@@ -115,21 +115,33 @@ export const useModelBuilder = () => {
     return `${originalFileName}_res${modelResolution}_pad${paddingFactor}_${timestamp}.stl`;
   }, [state.file, modelConfig]);
 
-  // Handle download functionality using the STL exporter
+  // Handle download functionality using the STL exporter with progress callbacks
   const downloadModel = useCallback(async () => {
     if (!localMesh || !stlExporterRef.current) return;
 
     try {
-      setLoading(true, 'Preparing 3D printable mesh...');
-      await new Promise(resolve => setTimeout(resolve, 100));
+      // Generate STL string using the STL exporter class with progress callbacks
+      const stlString = stlExporterRef.current.generateSTL(localMesh, {
+        callbacks: {
+          onCollectingGeometries: () => {
+            setLoading(true, 'Collecting mesh geometries...');
+          },
+          onProcessingOrientations: () => {
+            setLoading(true, 'Processing face orientations...');
+          },
+          onCreatingManifold: () => {
+            setLoading(true, 'Creating manifold mesh...');
+          },
+          onRemovingDegenerateTriangles: () => {
+            setLoading(true, 'Optimizing geometry...');
+          },
+          onGeneratingSTL: () => {
+            setLoading(true, 'Generating STL format...');
+          }
+        }
+      });
       
-      setLoading(true, 'Converting to STL format...');
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
-      // Generate STL string using the STL exporter class
-      const stlString = stlExporterRef.current.generateSTL(localMesh);
-      
-      setLoading(true, 'Saving file...');
+      setLoading(true, 'Preparing download...');
       await new Promise(resolve => setTimeout(resolve, 100));
       
       // Create blob and download

--- a/frontend/src/hooks/useModelBuilder.tsx
+++ b/frontend/src/hooks/useModelBuilder.tsx
@@ -121,22 +121,27 @@ export const useModelBuilder = () => {
 
     try {
       // Generate STL string using the STL exporter class with progress callbacks
-      const stlString = stlExporterRef.current.generateSTL(localMesh, {
+      const stlString = await stlExporterRef.current.generateSTL(localMesh, {
         callbacks: {
-          onCollectingGeometries: () => {
+          onCollectingGeometries: async () => {
             setLoading(true, 'Collecting mesh geometries...');
+            await new Promise(resolve => setTimeout(resolve, 200)); // Allow UI to update
           },
-          onProcessingOrientations: () => {
+          onProcessingOrientations: async () => {
             setLoading(true, 'Processing face orientations...');
+            await new Promise(resolve => setTimeout(resolve, 200)); // Allow UI to update
           },
-          onCreatingManifold: () => {
+          onCreatingManifold: async () => {
             setLoading(true, 'Creating manifold mesh...');
+            await new Promise(resolve => setTimeout(resolve, 200)); // Allow UI to update
           },
-          onRemovingDegenerateTriangles: () => {
+          onRemovingDegenerateTriangles: async () => {
             setLoading(true, 'Optimizing geometry...');
+            await new Promise(resolve => setTimeout(resolve, 200)); // Allow UI to update
           },
-          onGeneratingSTL: () => {
+          onGeneratingSTL: async () => {
             setLoading(true, 'Generating STL format...');
+            await new Promise(resolve => setTimeout(resolve, 200)); // Allow UI to update
           }
         }
       });

--- a/frontend/src/hooks/useModelBuilder.tsx
+++ b/frontend/src/hooks/useModelBuilder.tsx
@@ -1,11 +1,9 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useAppContext } from '../context/AppContext';
-import { Object3D, BufferGeometry, Mesh, Matrix4 } from 'three';
+import { Object3D } from 'three';
 import Renderer from '../lib/Renderer';
 import ModelBuilder from '../lib/ModelBuilder';
-import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js';
-import * as THREE from 'three';
-import { mergeVertices } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { STLExporter } from '../lib/STLExporter';
 
 export const useModelBuilder = () => {
   const { state, setLoading } = useAppContext();
@@ -16,11 +14,12 @@ export const useModelBuilder = () => {
   const [localMesh, setLocalMesh] = useState<Object3D | null>(null);
   const [pendingChanges, setPendingChanges] = useState<boolean>(false);
   const rendererRef = useRef<Renderer | null>(null);
+  const stlExporterRef = useRef<STLExporter | null>(null);
   const [isRendererInitialized, setIsRendererInitialized] = useState<boolean>(false);
   const initialRenderComplete = useRef<boolean>(false);
   const isBuildingModel = useRef<boolean>(false);
 
-  // Initialize renderer on mount
+  // Initialize renderer and STL exporter on mount
   useEffect(() => {
     document.body.classList.add('model-mode');
     
@@ -28,6 +27,10 @@ export const useModelBuilder = () => {
       const renderer = new Renderer('#scene-container');
       rendererRef.current = renderer;
       setIsRendererInitialized(true);
+    }
+
+    if (!stlExporterRef.current) {
+      stlExporterRef.current = new STLExporter();
     }
     
     return () => {
@@ -103,195 +106,55 @@ export const useModelBuilder = () => {
     setLoading(true, 'Updating model...');
   }, [setLoading]);
 
-  // Create a properly manifold mesh for 3D printing by rebuilding geometry connections
-  const createSingleMeshForExport = useCallback((group: Object3D): BufferGeometry => {
-    const allVertices: number[] = [];
-    const allIndices: number[] = [];
-    let vertexOffset = 0;
+  // Generate filename for STL export
+  const generateFileName = useCallback((): string => {
+    const originalFileName = state.file?.name.replace(/\.[^/.]+$/, '') || 'model';
+    const { modelResolution, paddingFactor } = modelConfig;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
     
-    // Step 1: Collect and prepare all geometries with consistent orientation
-    const processedGeometries: { positions: Float32Array; isBackSide: boolean }[] = [];
-    
-    group.traverse((child) => {
-      if (child instanceof Mesh && child.geometry) {
-        const geometry = child.geometry.clone();
-        
-        // Apply world matrix transformations
-        const worldMatrix = new Matrix4();
-        child.updateWorldMatrix(true, false);
-        worldMatrix.copy(child.matrixWorld);
-        geometry.applyMatrix4(worldMatrix);
-        
-        // Convert to non-indexed geometry
-        const nonIndexedGeo = geometry.index ? geometry.toNonIndexed() : geometry;
-        
-        // Check material orientation
-        const material = (child as Mesh).material as THREE.MeshStandardMaterial;
-        const isBackSide = material && material.side === THREE.BackSide;
-        
-        if (nonIndexedGeo.attributes.position) {
-          processedGeometries.push({
-            positions: nonIndexedGeo.attributes.position.array as Float32Array,
-            isBackSide
-          });
-        }
-      }
-    });
-    
-    // Step 2: Process each geometry with consistent face orientation
-    for (const { positions, isBackSide } of processedGeometries) {
-      const numVertices = positions.length / 3;
-      
-      // Add vertices with consistent winding
-      for (let i = 0; i < positions.length; i += 9) {
-        if (isBackSide) {
-          // Flip triangle winding for BackSide materials: v0, v2, v1
-          // v0
-          allVertices.push(positions[i], positions[i + 1], positions[i + 2]);
-          // v2 (was v1)
-          allVertices.push(positions[i + 6], positions[i + 7], positions[i + 8]);
-          // v1 (was v2)  
-          allVertices.push(positions[i + 3], positions[i + 4], positions[i + 5]);
-        } else {
-          // Keep original winding for FrontSide materials: v0, v1, v2
-          allVertices.push(
-            positions[i], positions[i + 1], positions[i + 2],     // v0
-            positions[i + 3], positions[i + 4], positions[i + 5], // v1
-            positions[i + 6], positions[i + 7], positions[i + 8]  // v2
-          );
-        }
-      }
-      
-      // Add indices for this geometry
-      for (let i = 0; i < numVertices; i++) {
-        allIndices.push(vertexOffset + i);
-      }
-      
-      vertexOffset += numVertices;
-    }
-    
-    if (allVertices.length === 0) {
-      throw new Error('No valid geometries found to export');
-    }
-    
-    // Step 3: Create final geometry with merged vertices to eliminate duplicates
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.Float32BufferAttribute(allVertices, 3));
-    geometry.setIndex(allIndices);
-    
-    // Step 4: Merge duplicate vertices to create manifold edges
-    const mergedGeometry = mergeVertices(geometry, 0.0001); // Small tolerance for floating point precision
-    
-    // Step 5: Final validation and normal computation
-    mergedGeometry.computeVertexNormals();
-    
-    // Step 6: Additional manifold validation - ensure no degenerate triangles
-    const finalPositions = mergedGeometry.attributes.position.array as Float32Array;
-    const finalIndices = mergedGeometry.index?.array;
-    
-    if (!finalIndices) {
-      throw new Error('Failed to create indexed geometry');
-    }
-    
-    // Remove degenerate triangles (triangles with zero area)
-    const validIndices: number[] = [];
-    const EPSILON = 1e-10;
-    
-    for (let i = 0; i < finalIndices.length; i += 3) {
-      const i1 = finalIndices[i] * 3;
-      const i2 = finalIndices[i + 1] * 3;
-      const i3 = finalIndices[i + 2] * 3;
-      
-      // Get triangle vertices
-      const v1 = new THREE.Vector3(finalPositions[i1], finalPositions[i1 + 1], finalPositions[i1 + 2]);
-      const v2 = new THREE.Vector3(finalPositions[i2], finalPositions[i2 + 1], finalPositions[i2 + 2]);
-      const v3 = new THREE.Vector3(finalPositions[i3], finalPositions[i3 + 1], finalPositions[i3 + 2]);
-      
-      // Calculate triangle area using cross product
-      const edge1 = v2.clone().sub(v1);
-      const edge2 = v3.clone().sub(v1);
-      const cross = edge1.clone().cross(edge2);
-      const area = cross.length() * 0.5;
-      
-      // Only include triangles with sufficient area
-      if (area > EPSILON) {
-        validIndices.push(finalIndices[i], finalIndices[i + 1], finalIndices[i + 2]);
-      }
-    }
-    
-    // Create final clean geometry
-    const cleanGeometry = new THREE.BufferGeometry();
-    cleanGeometry.setAttribute('position', mergedGeometry.attributes.position);
-    cleanGeometry.setIndex(validIndices);
-    cleanGeometry.computeVertexNormals();
-    
-    console.log(`Export: Created manifold mesh with ${validIndices.length / 3} triangles`);
-    return cleanGeometry;
-  }, []);
+    return `${originalFileName}_res${modelResolution}_pad${paddingFactor}_${timestamp}.stl`;
+  }, [state.file, modelConfig]);
 
-  // Handle download functionality with proper mesh merging for 3D printing
+  // Handle download functionality using the STL exporter
   const downloadModel = useCallback(async () => {
-    if (!localMesh) return;
+    if (!localMesh || !stlExporterRef.current) return;
 
     try {
       setLoading(true, 'Preparing 3D printable mesh...');
       await new Promise(resolve => setTimeout(resolve, 100));
       
-      // Create a single merged geometry for proper 3D printing
-      const printableGeometry = createSingleMeshForExport(localMesh);
-      
-      // Create a temporary mesh with the merged geometry
-      const printableMesh = new THREE.Mesh(printableGeometry);
-      
       setLoading(true, 'Converting to STL format...');
       await new Promise(resolve => setTimeout(resolve, 100));
       
-      const exporter = new STLExporter();
-      let stlString: string;
+      // Generate STL string using the STL exporter class
+      const stlString = stlExporterRef.current.generateSTL(localMesh);
       
-      try {
-        stlString = exporter.parse(printableMesh);
-      } catch (exportError) {
-        console.error('STL export failed:', exportError);
-        setLoading(true, `Export failed: ${exportError instanceof Error ? exportError.message : 'Unknown error'}`);
-        setTimeout(() => setLoading(false), 3000);
-        return;
-      }
-
       setLoading(true, 'Saving file...');
       await new Promise(resolve => setTimeout(resolve, 100));
       
+      // Create blob and download
       const blob = new Blob([stlString], { type: 'text/plain' });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
+      const link = document.createElement('a');
       
-      // Get the original filename from the GPX file
-      const originalFileName = state.file?.name.replace(/\.[^/.]+$/, '') || 'model';
+      link.href = url;
+      link.download = generateFileName();
+      link.click();
       
-      // Get render configs
-      const { modelResolution, paddingFactor } = modelConfig;
-      
-      // Create timestamp
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
-      
-      // Construct the filename with configs and timestamp
-      a.download = `${originalFileName}_res${modelResolution}_pad${paddingFactor}_${timestamp}.stl`;
-      
-      a.click();
+      // Cleanup
       URL.revokeObjectURL(url);
 
     } catch (error) {
-      console.error('Export failed completely:', error);
+      console.error('Export failed:', error);
       setLoading(true, `Export failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      setTimeout(() => setLoading(false), 3000);
+      setTimeout(() => setLoading(false), 10_000);
       return;
     }
 
     // Add delay before removing loading state
     await new Promise(resolve => setTimeout(resolve, 300));
     setLoading(false);
-  }, [localMesh, state.file, modelConfig, setLoading, createSingleMeshForExport]);
+  }, [localMesh, generateFileName, setLoading]);
 
   return {
     localMesh,

--- a/frontend/src/lib/STLExporter.test.ts
+++ b/frontend/src/lib/STLExporter.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { STLExporter } from "./STLExporter";
+import * as THREE from "three";
+
+describe("STLExporter", () => {
+  let stlExporter: STLExporter;
+
+  beforeEach(() => {
+    stlExporter = new STLExporter();
+  });
+
+  // Helper function to create a simple test mesh
+  const createTestMesh = (): THREE.Object3D => {
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshStandardMaterial();
+    const mesh = new THREE.Mesh(geometry, material);
+
+    const group = new THREE.Object3D();
+    group.add(mesh);
+
+    return group;
+  };
+
+  // Helper function to create a mesh with BackSide material
+  const createBackSideMesh = (): THREE.Object3D => {
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshStandardMaterial({ side: THREE.BackSide });
+    const mesh = new THREE.Mesh(geometry, material);
+
+    const group = new THREE.Object3D();
+    group.add(mesh);
+
+    return group;
+  };
+
+  // Helper function to create a complex mesh with multiple children
+  const createComplexMesh = (): THREE.Object3D => {
+    const group = new THREE.Object3D();
+
+    // Add multiple geometries
+    const box = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 1),
+      new THREE.MeshStandardMaterial()
+    );
+    box.position.set(0, 0, 0);
+
+    const sphere = new THREE.Mesh(
+      new THREE.SphereGeometry(0.5, 8, 6),
+      new THREE.MeshStandardMaterial()
+    );
+    sphere.position.set(2, 0, 0);
+
+    group.add(box);
+    group.add(sphere);
+
+    return group;
+  };
+
+  // Helper function to create an empty mesh group
+  const createEmptyMesh = (): THREE.Object3D => {
+    return new THREE.Object3D();
+  };
+
+  describe("generateSTL", () => {
+    it("should generate STL string from a simple mesh", async () => {
+      const mesh = createTestMesh();
+
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+      expect(stlString).toContain("solid");
+      expect(stlString).toContain("facet normal");
+      expect(stlString).toContain("vertex");
+      expect(stlString).toContain("endsolid");
+    });
+
+    it("should generate STL string from a complex mesh with multiple children", async () => {
+      const mesh = createComplexMesh();
+
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+      expect(stlString).toContain("solid");
+      expect(stlString).toContain("endsolid");
+    });
+
+    it("should handle BackSide materials correctly", async () => {
+      const mesh = createBackSideMesh();
+
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+    });
+
+    it("should throw error for empty mesh", async () => {
+      const emptyMesh = createEmptyMesh();
+
+      await expect(async () => {
+        await stlExporter.generateSTL(emptyMesh);
+      }).rejects.toThrow("No valid geometries found to export");
+    });
+  });
+
+  describe("callbacks", () => {
+    it("should call all callbacks in correct order", async () => {
+      const mesh = createTestMesh();
+      const callbacks = {
+        onCollectingGeometries: vi.fn().mockResolvedValue(undefined),
+        onProcessingOrientations: vi.fn().mockResolvedValue(undefined),
+        onCreatingManifold: vi.fn().mockResolvedValue(undefined),
+        onRemovingDegenerateTriangles: vi.fn().mockResolvedValue(undefined),
+        onGeneratingSTL: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const stlString = await stlExporter.generateSTL(mesh, { callbacks });
+
+      expect(stlString).toBeDefined();
+      expect(callbacks.onCollectingGeometries).toHaveBeenCalledTimes(1);
+      expect(callbacks.onProcessingOrientations).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCreatingManifold).toHaveBeenCalledTimes(1);
+      expect(callbacks.onRemovingDegenerateTriangles).toHaveBeenCalledTimes(1);
+      expect(callbacks.onGeneratingSTL).toHaveBeenCalledTimes(1);
+
+      // Verify call order - each callback should be called before the next one
+      expect(callbacks.onCollectingGeometries).toHaveBeenCalledBefore(
+        callbacks.onProcessingOrientations
+      );
+      expect(callbacks.onProcessingOrientations).toHaveBeenCalledBefore(
+        callbacks.onCreatingManifold
+      );
+      expect(callbacks.onCreatingManifold).toHaveBeenCalledBefore(
+        callbacks.onRemovingDegenerateTriangles
+      );
+      expect(callbacks.onRemovingDegenerateTriangles).toHaveBeenCalledBefore(
+        callbacks.onGeneratingSTL
+      );
+    });
+
+    it("should work without callbacks", async () => {
+      const mesh = createTestMesh();
+
+      await expect(async () => {
+        const stlString = await stlExporter.generateSTL(mesh);
+        expect(stlString).toBeDefined();
+      }).not.toThrow();
+    });
+
+    it("should work with partial callbacks", async () => {
+      const mesh = createTestMesh();
+      const callbacks = {
+        onCollectingGeometries: vi.fn().mockResolvedValue(undefined),
+        onGeneratingSTL: vi.fn().mockResolvedValue(undefined),
+        // Other callbacks intentionally omitted
+      };
+
+      const stlString = await stlExporter.generateSTL(mesh, { callbacks });
+
+      expect(stlString).toBeDefined();
+      expect(callbacks.onCollectingGeometries).toHaveBeenCalledTimes(1);
+      expect(callbacks.onGeneratingSTL).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle callback errors gracefully", async () => {
+      const mesh = createTestMesh();
+      const callbacks = {
+        onCollectingGeometries: vi
+          .fn()
+          .mockRejectedValue(new Error("Callback error")),
+      };
+
+      // The STL generation should propagate callback errors
+      await expect(async () => {
+        await stlExporter.generateSTL(mesh, { callbacks });
+      }).rejects.toThrow("Callback error");
+    });
+
+    it("should handle async callbacks with delays", async () => {
+      const mesh = createTestMesh();
+      const callOrder: string[] = [];
+
+      const callbacks = {
+        onCollectingGeometries: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          callOrder.push("collecting");
+        }),
+        onProcessingOrientations: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          callOrder.push("processing");
+        }),
+        onCreatingManifold: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 15));
+          callOrder.push("manifold");
+        }),
+        onRemovingDegenerateTriangles: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 8));
+          callOrder.push("optimizing");
+        }),
+        onGeneratingSTL: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 3));
+          callOrder.push("generating");
+        }),
+      };
+
+      const stlString = await stlExporter.generateSTL(mesh, { callbacks });
+
+      expect(stlString).toBeDefined();
+      expect(callOrder).toEqual([
+        "collecting",
+        "processing",
+        "manifold",
+        "optimizing",
+        "generating",
+      ]);
+      expect(callbacks.onCollectingGeometries).toHaveBeenCalledTimes(1);
+      expect(callbacks.onProcessingOrientations).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCreatingManifold).toHaveBeenCalledTimes(1);
+      expect(callbacks.onRemovingDegenerateTriangles).toHaveBeenCalledTimes(1);
+      expect(callbacks.onGeneratingSTL).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("mesh processing", () => {
+    it("should handle meshes with transformations", async () => {
+      const mesh = createTestMesh();
+
+      // Apply transformations
+      mesh.position.set(10, 20, 30);
+      mesh.rotation.set(Math.PI / 4, Math.PI / 2, 0);
+      mesh.scale.set(2, 0.5, 1.5);
+      mesh.updateMatrix();
+
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+    });
+
+    it("should process indexed geometries correctly", async () => {
+      const geometry = new THREE.SphereGeometry(1, 8, 6);
+      const material = new THREE.MeshStandardMaterial();
+      const mesh = new THREE.Mesh(geometry, material);
+
+      const group = new THREE.Object3D();
+      group.add(mesh);
+
+      const stlString = await stlExporter.generateSTL(group);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+    });
+
+    it("should process non-indexed geometries correctly", async () => {
+      const geometry = new THREE.BoxGeometry(1, 1, 1).toNonIndexed();
+      const material = new THREE.MeshStandardMaterial();
+      const mesh = new THREE.Mesh(geometry, material);
+
+      const group = new THREE.Object3D();
+      group.add(mesh);
+
+      const stlString = await stlExporter.generateSTL(group);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle mesh with no position attribute", async () => {
+      const geometry = new THREE.BufferGeometry();
+      // Intentionally not adding position attribute
+      const material = new THREE.MeshStandardMaterial();
+      const mesh = new THREE.Mesh(geometry, material);
+
+      const group = new THREE.Object3D();
+      group.add(mesh);
+
+      await expect(async () => {
+        await stlExporter.generateSTL(group);
+      }).rejects.toThrow("No valid geometries found to export");
+    });
+
+    it("should handle deeply nested mesh hierarchy", async () => {
+      const root = new THREE.Object3D();
+      const level1 = new THREE.Object3D();
+      const level2 = new THREE.Object3D();
+
+      const geometry = new THREE.BoxGeometry(1, 1, 1);
+      const material = new THREE.MeshStandardMaterial();
+      const mesh = new THREE.Mesh(geometry, material);
+
+      level2.add(mesh);
+      level1.add(level2);
+      root.add(level1);
+
+      const stlString = await stlExporter.generateSTL(root);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+    });
+
+    it("should handle mixed mesh types in group", async () => {
+      const group = new THREE.Object3D();
+
+      // Add a mesh
+      const boxMesh = new THREE.Mesh(
+        new THREE.BoxGeometry(1, 1, 1),
+        new THREE.MeshStandardMaterial()
+      );
+
+      // Add a non-mesh object that should be ignored
+      const emptyObject = new THREE.Object3D();
+
+      // Add another mesh with BackSide material
+      const sphereMesh = new THREE.Mesh(
+        new THREE.SphereGeometry(0.5, 8, 6),
+        new THREE.MeshStandardMaterial({ side: THREE.BackSide })
+      );
+
+      group.add(boxMesh);
+      group.add(emptyObject);
+      group.add(sphereMesh);
+
+      const stlString = await stlExporter.generateSTL(group);
+
+      expect(stlString).toBeDefined();
+      expect(typeof stlString).toBe("string");
+      expect(stlString.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("STL format validation", () => {
+    it("should produce valid STL header and footer", async () => {
+      const mesh = createTestMesh();
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      const lines = stlString.trim().split("\n");
+      expect(lines[0]).toMatch(/^solid/);
+      expect(lines[lines.length - 1]).toMatch(/^endsolid/);
+    });
+
+    it("should contain proper facet structure", async () => {
+      const mesh = createTestMesh();
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      expect(stlString).toMatch(/facet normal/);
+      expect(stlString).toMatch(/outer loop/);
+      expect(stlString).toMatch(/vertex/);
+      expect(stlString).toMatch(/endloop/);
+      expect(stlString).toMatch(/endfacet/);
+    });
+
+    it("should have consistent vertex count per facet", async () => {
+      const mesh = createTestMesh();
+      const stlString = await stlExporter.generateSTL(mesh);
+
+      // Count facets and vertices
+      const facetMatches = stlString.match(/facet normal/g);
+      const vertexMatches = stlString.match(/vertex/g);
+
+      expect(facetMatches).toBeTruthy();
+      expect(vertexMatches).toBeTruthy();
+
+      if (facetMatches && vertexMatches) {
+        // Each facet should have exactly 3 vertices
+        expect(vertexMatches.length).toBe(facetMatches.length * 3);
+      }
+    });
+  });
+});

--- a/frontend/src/lib/STLExporter.ts
+++ b/frontend/src/lib/STLExporter.ts
@@ -1,0 +1,199 @@
+import { Object3D, BufferGeometry, Mesh, Matrix4 } from "three";
+import { STLExporter as ThreeSTLExporter } from "three/examples/jsm/exporters/STLExporter.js";
+import * as THREE from "three";
+import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+
+export class STLExporter {
+  private exporter: ThreeSTLExporter;
+
+  constructor() {
+    this.exporter = new ThreeSTLExporter();
+  }
+
+  /**
+   * Creates a properly manifold mesh for 3D printing by rebuilding geometry connections
+   */
+  private createPrintableMesh(group: Object3D): BufferGeometry {
+    const allVertices: number[] = [];
+    const allIndices: number[] = [];
+    let vertexOffset = 0;
+
+    // Step 1: Collect and prepare all geometries with consistent orientation
+    const processedGeometries: {
+      positions: Float32Array;
+      isBackSide: boolean;
+    }[] = [];
+
+    group.traverse((child) => {
+      if (child instanceof Mesh && child.geometry) {
+        const geometry = child.geometry.clone();
+
+        // Apply world matrix transformations
+        const worldMatrix = new Matrix4();
+        child.updateWorldMatrix(true, false);
+        worldMatrix.copy(child.matrixWorld);
+        geometry.applyMatrix4(worldMatrix);
+
+        // Convert to non-indexed geometry
+        const nonIndexedGeo = geometry.index
+          ? geometry.toNonIndexed()
+          : geometry;
+
+        // Check material orientation
+        const material = (child as Mesh).material as THREE.MeshStandardMaterial;
+        const isBackSide = material && material.side === THREE.BackSide;
+
+        if (nonIndexedGeo.attributes.position) {
+          processedGeometries.push({
+            positions: nonIndexedGeo.attributes.position.array as Float32Array,
+            isBackSide,
+          });
+        }
+      }
+    });
+
+    // Step 2: Process each geometry with consistent face orientation
+    for (const { positions, isBackSide } of processedGeometries) {
+      const numVertices = positions.length / 3;
+
+      // Add vertices with consistent winding
+      for (let i = 0; i < positions.length; i += 9) {
+        if (isBackSide) {
+          // Flip triangle winding for BackSide materials: v0, v2, v1
+          allVertices.push(
+            positions[i],
+            positions[i + 1],
+            positions[i + 2], // v0
+            positions[i + 6],
+            positions[i + 7],
+            positions[i + 8], // v2 (was v1)
+            positions[i + 3],
+            positions[i + 4],
+            positions[i + 5] // v1 (was v2)
+          );
+        } else {
+          // Keep original winding for FrontSide materials: v0, v1, v2
+          allVertices.push(
+            positions[i],
+            positions[i + 1],
+            positions[i + 2], // v0
+            positions[i + 3],
+            positions[i + 4],
+            positions[i + 5], // v1
+            positions[i + 6],
+            positions[i + 7],
+            positions[i + 8] // v2
+          );
+        }
+      }
+
+      // Add indices for this geometry
+      for (let i = 0; i < numVertices; i++) {
+        allIndices.push(vertexOffset + i);
+      }
+
+      vertexOffset += numVertices;
+    }
+
+    if (allVertices.length === 0) {
+      throw new Error("No valid geometries found to export");
+    }
+
+    return this.createManifoldGeometry(allVertices, allIndices);
+  }
+
+  /**
+   * Creates a manifold geometry by merging vertices and removing degenerate triangles
+   */
+  private createManifoldGeometry(
+    vertices: number[],
+    indices: number[]
+  ): BufferGeometry {
+    // Create geometry with merged vertices to eliminate duplicates
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute(
+      "position",
+      new THREE.Float32BufferAttribute(vertices, 3)
+    );
+    geometry.setIndex(indices);
+
+    // Merge duplicate vertices to create manifold edges
+    const mergedGeometry = mergeVertices(geometry, 0.0001); // Small tolerance for floating point precision
+    mergedGeometry.computeVertexNormals();
+
+    // Remove degenerate triangles and create final clean geometry
+    return this.removeDegenearteTriangles(mergedGeometry);
+  }
+
+  /**
+   * Removes degenerate triangles (triangles with zero area)
+   */
+  private removeDegenearteTriangles(geometry: BufferGeometry): BufferGeometry {
+    const positions = geometry.attributes.position.array as Float32Array;
+    const indices = geometry.index?.array;
+
+    if (!indices) {
+      throw new Error("Failed to create indexed geometry");
+    }
+
+    const validIndices: number[] = [];
+    const EPSILON = 1e-10;
+
+    for (let i = 0; i < indices.length; i += 3) {
+      const i1 = indices[i] * 3;
+      const i2 = indices[i + 1] * 3;
+      const i3 = indices[i + 2] * 3;
+
+      // Get triangle vertices
+      const v1 = new THREE.Vector3(
+        positions[i1],
+        positions[i1 + 1],
+        positions[i1 + 2]
+      );
+      const v2 = new THREE.Vector3(
+        positions[i2],
+        positions[i2 + 1],
+        positions[i2 + 2]
+      );
+      const v3 = new THREE.Vector3(
+        positions[i3],
+        positions[i3 + 1],
+        positions[i3 + 2]
+      );
+
+      // Calculate triangle area using cross product
+      const edge1 = v2.clone().sub(v1);
+      const edge2 = v3.clone().sub(v1);
+      const cross = edge1.clone().cross(edge2);
+      const area = cross.length() * 0.5;
+
+      // Only include triangles with sufficient area
+      if (area > EPSILON) {
+        validIndices.push(indices[i], indices[i + 1], indices[i + 2]);
+      }
+    }
+
+    // Create final clean geometry
+    const cleanGeometry = new THREE.BufferGeometry();
+    cleanGeometry.setAttribute("position", geometry.attributes.position);
+    cleanGeometry.setIndex(validIndices);
+    cleanGeometry.computeVertexNormals();
+
+    console.log(
+      `Export: Created manifold mesh with ${validIndices.length / 3} triangles`
+    );
+    return cleanGeometry;
+  }
+
+  /**
+   * Converts a 3D model to STL format and returns the STL string
+   */
+  generateSTL(mesh: Object3D): string {
+    // Create a printable mesh
+    const printableGeometry = this.createPrintableMesh(mesh);
+    const printableMesh = new THREE.Mesh(printableGeometry);
+
+    // Export to STL string
+    return this.exporter.parse(printableMesh);
+  }
+}


### PR DESCRIPTION
## Overview

This PR refactors the STL export functionality by extracting complex export logic from the `useModelBuilder` hook into a dedicated `STLExporter` class. The refactoring improves code organization, maintainability, and adds support for async progress callbacks.

## Changes Made

### 🏗️ **New STLExporter Class** (`frontend/src/lib/STLExporter.ts`)
- Dedicated class for handling STL export operations
- Processes 3D meshes into printable manifold geometry 
- Removes degenerate triangles and merges vertices for clean output
- Supports async progress callbacks for UI updates
- Clean separation of mesh processing from UI concerns

### 🧪 **Comprehensive Test Suite** (`frontend/src/lib/STLExporter.test.ts`)
- 18 test cases covering all functionality and edge cases
- Tests for mesh processing, callback handling, and STL format validation
- Async callback testing with proper mock implementations
- Edge case coverage for empty meshes, transformations, and nested hierarchies

### ♻️ **Refactored useModelBuilder Hook** (`frontend/src/hooks/useModelBuilder.tsx`)
- Simplified hook by delegating STL export to dedicated class
- Enhanced progress updates with granular status messages
- Async callback support for non-blocking UI updates
- Cleaner separation between model building and file export

## Benefits

- **Better Code Organization**: Clear separation of concerns between UI state management and STL processing
- **Improved Maintainability**: Complex export logic isolated in testable class
- **Enhanced User Experience**: Detailed progress updates during export process
- **Future Extensibility**: Async callbacks enable advanced progress tracking
- **Robust Testing**: Comprehensive test coverage ensures reliability

## Technical Details

- All callbacks are now async (`Promise<void>`) for non-blocking operations
- STL export process includes 5 distinct stages with progress feedback
- Maintains backward compatibility with existing functionality
- Zero breaking changes to public APIs